### PR TITLE
Do not test TF 2.6.2 against on Python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         py-version: ['3.7', '3.8', '3.9', '3.10']
         tf-version: ['2.6.2', '2.8.0']
         cpu: ['x86']
+        exclude:
+          - py-version: '3.10'
+          - tf-version: '2.6.2'
         include:
           - os: 'macos-11'
             cpu: 'arm64'


### PR DESCRIPTION
TF 2.6 doesn't support Python 3.10 yet, so this PR removes this combination from the CI matrix.

Fixes https://github.com/tensorflow/addons/pull/2635#discussion_r800607481