### PR TITLE
Fix GitHub actions exclude syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         cpu: ['x86']
         exclude:
           - py-version: '3.10'
-          - tf-version: '2.6.2'
+            tf-version: '2.6.2'
         include:
           - os: 'macos-11'
             cpu: 'arm64'


### PR DESCRIPTION
I messed up the syntax in #18 so this PR should correct the behaviour and not exclude all builds with either Python 3.10 or TF 2.6.

Sorry about that 🙈 